### PR TITLE
feat: multi project deployments

### DIFF
--- a/dagster_uc/config.py
+++ b/dagster_uc/config.py
@@ -35,6 +35,7 @@ class UserCodeDeploymentsConfig:
     dagster_gui_url: str | None = None
     verbose: bool = False
     use_az_login: bool = True
+    use_project_name: bool = True
     user_code_deployments_configmap_name: str = "dagster-user-deployments-values-yaml"
     dagster_workspace_yaml_configmap_name: str = "dagster-workspace-yaml"
     uc_deployment_semaphore_name: str = "dagster-uc-semaphore"

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -213,6 +213,9 @@ def deployment_revive(
     ],
     tag: Annotated[str, typer.Option("--tag", "-t", help="The tag of the deployment to revive.")],
 ):
+    # In case the UI name separator of the deployment is passed
+    name = name.replace(":", "--")
+
     if not handler._check_deployment_exists(
         name,
     ):
@@ -272,6 +275,9 @@ def deployment_delete(
                 deployment_name_suffix="",
                 use_project_name=config.use_project_name,
             )
+        else:
+            # In case the UI name separator of the deployment is passed
+            name = name.replace(":", "--")
         handler.remove_user_deployment_from_configmap(name)
         handler.delete_k8s_resources_for_user_deployment(
             name,
@@ -303,6 +309,9 @@ def check_deployment(
     """This function executes before any other nested cli command is called and loads the configuration object."""
     if not name:
         name = handler.get_deployment_name(use_project_name=config.use_project_name)
+    else:
+        # In case the UI name separator of the deployment is passed
+        name = name.replace(":", "--")
     if not handler._check_deployment_exists(name):
         logger.warning(
             f"Deployment with name '{name}' does not seem to exist in environment '{config.environment}'. Attempting to proceed with status check anyways.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-uc"
-version = "0.2.4"
+version = "0.3.0"
 authors = [
     {name = "Stefan Verbruggen"}, 
     {name = "Ion Koutsouris"},
@@ -20,6 +20,7 @@ dependencies = [
     "kr8s < 1.0",
     "pyhelm3==0.3.3",
     "typer==0.12.3",
+    "tomli",
     "pyyaml",
     "pytz"
 ]


### PR DESCRIPTION
This will be a breaking change, by default a branch of your user code will get prefixed by the project name. The project name is fetched from the pyproject.toml.

All k8s objects use the name `{project_name}--{branch | environment}`. In the UI your branch will be visible as `{project_name}:{branch | environment}`.

Passing the names in the CLI can be done with the UI name or the k8s compatible name