### PR TITLE
perf: use IfNotPresent pull policy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build a binary wheel
         run: uv build .
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: my_dists/

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -277,7 +277,7 @@ class DagsterUserCodeHandler:
                     name,
                 ),
                 "tag": tag,
-                "pullPolicy": "IfNotPresent", # Safe, due to versioning of each deployment image
+                "pullPolicy": "IfNotPresent",  # Safe, due to versioning of each deployment image
             },
             "dagsterApiGrpcArgs": [
                 "-f",

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -277,7 +277,7 @@ class DagsterUserCodeHandler:
                     name,
                 ),
                 "tag": tag,
-                "pullPolicy": "Always",
+                "pullPolicy": "IfNotPresent", # Safe, due to versioning of each deployment image
             },
             "dagsterApiGrpcArgs": [
                 "-f",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-uc"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     {name = "Stefan Verbruggen"}, 
     {name = "Ion Koutsouris"},


### PR DESCRIPTION
Due to guarantees of versioning an image with +1 each time, we can safely assume an image won't be updated in place with the same version, hence IfNotPresent is a good default so we can use a cached image