### PR TITLE
refactor: manage user-code release through helm

### DIFF
--- a/dagster_uc/utils.py
+++ b/dagster_uc/utils.py
@@ -186,3 +186,18 @@ def build_and_push(
         cmd = ["sudo"] + cmd
     exception_on_failed_subprocess(subprocess.run(cmd, capture_output=False))
     os.chdir(previous_dir)
+
+
+def is_command_available(command: str) -> bool:
+    """Checks if command is available."""
+    try:
+        subprocess.run(
+            [command, "--version"],
+            capture_output=True,
+            check=True,  # ruff: ignore
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+    except FileNotFoundError:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-uc"
-version = "0.3.5"
+version = "0.4.0"
 authors = [
     {name = "Stefan Verbruggen"},
     {name = "Ion Koutsouris"},


### PR DESCRIPTION
Instead of applying each individual object, it's easier to go through helm for this. This also allows you then to easily rollback when a deployment fails (built-in) or manually intervene and roll back the helm release.