### PR TITLE
Feat adjust pod name prefix

### DIFF
--- a/dagster_uc/config.py
+++ b/dagster_uc/config.py
@@ -50,9 +50,7 @@ class UserCodeDeploymentsConfig:
     user_code_deployments_configmap_name: str = "dagster-user-deployments-values-yaml"
     dagster_workspace_yaml_configmap_name: str = "dagster-workspace-yaml"
     uc_deployment_semaphore_name: str = "dagster-uc-semaphore"
-    uc_release_name: str = 'dagster-user-code'
-    
-
+    uc_release_name: str = "dagster-user-code"
 
 
 def load_config(environment: str, path: str | None) -> UserCodeDeploymentsConfig:

--- a/dagster_uc/config.py
+++ b/dagster_uc/config.py
@@ -50,6 +50,9 @@ class UserCodeDeploymentsConfig:
     user_code_deployments_configmap_name: str = "dagster-user-deployments-values-yaml"
     dagster_workspace_yaml_configmap_name: str = "dagster-workspace-yaml"
     uc_deployment_semaphore_name: str = "dagster-uc-semaphore"
+    uc_release_name: str = 'dagster-user-code'
+    
+
 
 
 def load_config(environment: str, path: str | None) -> UserCodeDeploymentsConfig:

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -191,7 +191,7 @@ class DagsterUserCodeHandler:
         if self.config.use_az_login and self.config.container_registry_chart_path is not None:
             login_registry_helm(self.config.container_registry)
 
-        RELEASE_NAME = "dagster-user-code"  # noqa
+        RELEASE_NAME = self.config.uc_release_name  # noqa
         helm_client = Client(kubecontext=self.config.kubernetes_context)
 
         if self.config.container_registry_chart_path is None:
@@ -321,7 +321,7 @@ class DagsterUserCodeHandler:
             "startupProbe": {"enabled": False},
             "service": {
                 "annotations": {
-                    "meta.helm.sh/release-name": "dagster-user-code",
+                    "meta.helm.sh/release-name": self.config.uc_release_name,
                     "meta.helm.sh/release-namespace": self.config.namespace,
                 },
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-uc"
-version = "0.5.4"
+version = "0.5.6"
 authors = [
     {name = "Stefan Verbruggen"},
     {name = "Ion Koutsouris"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyyaml",
     "pytz",
     "pydantic>=2",
+    "packaging>=25.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Added the ability to control the release name via the config using the variable name uc_release_name. This defaults to 'dagster-user-code' if not set. Also fixed an issue where packaging is not downloaded if the dev-dependcies aren't downloaded as this can break CI/CD. 