### PR TITLE
Add Project Override configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The configuration format is now nested and grouped by concerns (e.g. `docker`, `
 * `kubernetes` — Kubernetes-specific settings (context, namespace, resource requests/limits, env and secret lists).
 * `helm` — Helm-related settings (for example, skip schema validation).
 * `chart` — chart-specific values you may want to supply into the user-deployments Helm chart.
-* `use_latest_chart_version` and `use_project_name` — deployment behavior flags.
+* `use_latest_chart_version`, `use_project_name`, and `project_name_override` — deployment behavior flags.
 
 Order of loading configuration:
 1. `defaults`
@@ -50,7 +50,6 @@ defaults:
   cicd: false
   use_project_name: True
   use_latest_chart_version: True
-
   # Docker configuration (grouped under `docker`)
   docker:
     docker_root: "."
@@ -99,6 +98,7 @@ dev:
 acc:
   environment: acc
   dagster_gui_url: "http://dagster.acc"
+  project_name_override: 'example-acc'
 
   docker:
     dockerfile: "docker/acc.Dockerfile"
@@ -127,6 +127,7 @@ Notes on common config keys (now nested):
 * `kubernetes.user_code_deployment_env_secrets` — a list of secrets to be mounted/injected as environment variables.
 * `helm.skip_schema_validation` — useful for older Helm chart setups or when schema validation causes issues.
 * `use_project_name` — when True, the project name from `pyproject.toml` is prefixed to the deployment name.
+* `project_name_override` - When set, the project name from `pyproject.toml` is overridden with this value
 
 ### Overriding Config with Environment Variables
 

--- a/dagster_uc/config.py
+++ b/dagster_uc/config.py
@@ -177,6 +177,7 @@ class DagsterUserCodeConfiguration(_BaseSettingsWithYamlAndEnv):
     dagster_gui_url: str | None = Field(default=None)
     verbose: bool = Field(default=False)
     use_project_name: bool = Field(default=True)
+    project_name_override: str = Field(default="")
     use_latest_chart_version: bool = False
 
     docker_config: DockerConfiguration = Field(default_factory=DockerConfiguration, alias="docker")  # type: ignore

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -298,11 +298,13 @@ def deployment_delete(
         elif branch is not None:
             name = handler.get_deployment_name(
                 use_project_name=config.use_project_name,
+                project_name_override=config.project_name_override,
                 branch=branch,
             ).full_name
         else:
             name = handler.get_deployment_name(
                 use_project_name=config.use_project_name,
+                project_name_override=config.project_name_override,
             ).full_name
 
         handler.remove_user_deployment_from_configmap(name)
@@ -432,6 +434,7 @@ def deployment_deploy(
             dagster_deployment = handler.get_deployment_name(
                 deployment_name_suffix,
                 use_project_name=config.use_project_name,
+                project_name_override=config.project_name_override,
             )
             (deployment_name, branch_name) = (
                 dagster_deployment.full_name,

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -99,6 +99,9 @@ def init_config(
         use_project_name=typer.confirm(
             "Whether to use the pyproject.toml project-name as deployment name prefix.",
         ),
+        project_name_override=typer.confirm(
+            "Override deployment name prefix if not empty",
+        ),
         docker=DockerConfiguration(
             docker_root=typer.prompt("Path of docker scope", default="."),
             dockerfile=typer.prompt("Path of dockerfile", default="./Dockerfile"),
@@ -328,7 +331,10 @@ def check_deployment(
 ) -> None:
     """This function executes before any other nested cli command is called and loads the configuration object."""
     if not name:
-        name = handler.get_deployment_name(use_project_name=config.use_project_name).full_name
+        name = handler.get_deployment_name(
+            use_project_name=config.use_project_name,
+            project_name_override=config.project_name_override,
+        ).full_name
     else:
         # In case the UI name separator of the deployment is passed
         name = name.replace(":", "--")

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -476,6 +476,7 @@ class DagsterUserCodeHandler:
             project_name = self._get_project_name()
         else:
             project_name = None
+        print(project_name)
         if self.config.cicd and branch is None:
             branch = self.config.environment
         else:

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -464,13 +464,19 @@ class DagsterUserCodeHandler:
         self,
         deployment_name_suffix: str | None = None,
         use_project_name: bool = True,
+        project_name_override: str = "",
         branch: str | None = None,
     ) -> DagsterDeployment:
         """Creates a deployment name based on the name of the pyproject.toml and name of git branch"""
         logger.debug("Determining deployment name...")
 
-        project_name = self._get_project_name() if use_project_name else None
-
+        # project_name = self._get_project_name() if use_project_name else None
+        if project_name_override != "":
+            project_name = project_name_override
+        elif use_project_name:
+            project_name = self._get_project_name()
+        else:
+            project_name = None
         if self.config.cicd and branch is None:
             branch = self.config.environment
         else:

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -476,7 +476,6 @@ class DagsterUserCodeHandler:
             project_name = self._get_project_name()
         else:
             project_name = None
-        print(project_name)
         if self.config.cicd and branch is None:
             branch = self.config.environment
         else:

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -470,7 +470,6 @@ class DagsterUserCodeHandler:
         """Creates a deployment name based on the name of the pyproject.toml and name of git branch"""
         logger.debug("Determining deployment name...")
 
-        # project_name = self._get_project_name() if use_project_name else None
         if project_name_override != "":
             project_name = project_name_override
         elif use_project_name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-uc"
-version = "0.6.5"
+version = "0.6.6"
 authors = [
     {name = "Stefan Verbruggen"},
     {name = "Ion Koutsouris"},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from dagster_uc.config import load_config
                 "dagster_gui_url": "http://dagster.dev",
                 "verbose": False,
                 "use_project_name": True,
+                "project_name_override": "",
                 "use_latest_chart_version": True,
                 "docker_config": {
                     "container_registry": "dagster-uc.dev.acr.io",
@@ -67,6 +68,7 @@ from dagster_uc.config import load_config
                 "dagster_gui_url": "http://dagster.acc",
                 "verbose": False,
                 "use_project_name": True,
+                "project_name_override": "",
                 "use_latest_chart_version": True,
                 "docker_config": {
                     "container_registry": "dagster-uc.acc.acr.io",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "dagster-uc"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "kr8s" },


### PR DESCRIPTION
Adding an option for overriding the project name for cases where we want to use the automatic project-name prepending, but specifically not the pyproject.toml name, such as uv workspaces where there are multiple projects under the overarching project. If override is set to not be a empty string, it will override the automatically generated project name.  