### PR TITLE
Fixing a tuple declaration for metadata.name that results in a json unpacking error for brand new configmaps

### DIFF
--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -56,7 +56,7 @@ class DagsterUserCodeHandler:
         # Create configmap manifest
         dagster_user_deployments_values_yaml_configmap = deepcopy(BASE_CONFIGMAP)
         dagster_user_deployments_values_yaml_configmap["metadata"]["name"] = (
-            self.config.dagster_chart_config.deployments_configmap_name,
+            self.config.dagster_chart_config.deployments_configmap_name
         )
         # dump raw yaml of the configmap data content into the configmap
         dagster_user_deployments_values_yaml_configmap["data"]["yaml"] = yaml.dump(


### PR DESCRIPTION
Discovered a bug where a tuple declaration (due to a comma) for metadata.name where the configmap is brand new causes an error in configmap generation. 