### PR TITLE
Feat pull policy addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ defaults:
       memory: 2000Mi
     user_code_deployment_env_secrets:
       - name: dagster-storage-secret
+    pull_policy: Always
 
   chart: {}
 
@@ -94,7 +95,7 @@ dev:
         value: '1'
       - name: ENVIRONMENT
         value: dev
-
+    pull_policy: IfNotPresent
 acc:
   environment: acc
   dagster_gui_url: "http://dagster.acc"
@@ -125,6 +126,7 @@ Notes on common config keys (now nested):
 * `kubernetes.requests` / `kubernetes.limits` — resource requests and limits for the user code deployment pod.
 * `kubernetes.user_code_deployment_env` — a list of name/value env objects to inject into the user-code deployment container.
 * `kubernetes.user_code_deployment_env_secrets` — a list of secrets to be mounted/injected as environment variables.
+* `kubernetes.pull_policy` - Standard Kubernetes Pull Policy for images, can either be 'IfNotPresent' or 'Always'
 * `helm.skip_schema_validation` — useful for older Helm chart setups or when schema validation causes issues.
 * `use_project_name` — when True, the project name from `pyproject.toml` is prefixed to the deployment name.
 * `project_name_override` - When set, the project name from `pyproject.toml` is overridden with this value

--- a/dagster_uc/config.py
+++ b/dagster_uc/config.py
@@ -154,7 +154,8 @@ class KubernetesConfiguration(BaseModel):
     requests: KubernetesResource | None = Field(default=None)
     service_account_annotations: dict = Field(default={})
     pod_labels: dict = Field(default={})
-    pull_policy: Literal["IfNotPresent", 'Always'] = "IfNotPresent"
+    pull_policy: Literal["IfNotPresent", "Always"] = "IfNotPresent"
+
 
 class DagsterUserCodeChartConfiguration(BaseModel):
     """User code chart configuration"""

--- a/dagster_uc/config.py
+++ b/dagster_uc/config.py
@@ -154,7 +154,7 @@ class KubernetesConfiguration(BaseModel):
     requests: KubernetesResource | None = Field(default=None)
     service_account_annotations: dict = Field(default={})
     pod_labels: dict = Field(default={})
-
+    pull_policy: Literal["IfNotPresent", 'Always'] = "IfNotPresent"
 
 class DagsterUserCodeChartConfiguration(BaseModel):
     """User code chart configuration"""

--- a/dagster_uc/uc_handler.py
+++ b/dagster_uc/uc_handler.py
@@ -295,7 +295,7 @@ class DagsterUserCodeHandler:
                     name,
                 ),
                 "tag": tag,
-                "pullPolicy": "IfNotPresent",  # Safe, due to versioning of each deployment image
+                "pullPolicy": self.config.kubernetes_config.pull_policy,  # Safe, due to versioning of each deployment image
             },
             "dagsterApiGrpcArgs": [
                 "-f",

--- a/tests/config/.config_user_code_deployments.yaml
+++ b/tests/config/.config_user_code_deployments.yaml
@@ -65,3 +65,4 @@ acc:
         value: '1'
       - name: ENVIRONMENT
         value: acc
+    pull_policy: Always

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,7 +101,6 @@ from dagster_uc.config import load_config
                     "limits": {"cpu": "4000m", "memory": "2000Mi"},
                     "requests": {"cpu": "150m", "memory": "750Mi"},
                     "pull_policy": "Always",
-
                 },
                 "dagster_chart_config": {
                     "deployments_configmap_name": "dagster-user-deployments-values-yaml",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,7 @@ from dagster_uc.config import load_config
                     "pod_labels": {},
                     "limits": {"cpu": "4000m", "memory": "2000Mi"},
                     "requests": {"cpu": "150m", "memory": "750Mi"},
+                    "pull_policy": "IfNotPresent",
                 },
                 "dagster_chart_config": {
                     "deployments_configmap_name": "dagster-user-deployments-values-yaml",
@@ -99,6 +100,8 @@ from dagster_uc.config import load_config
                     "pod_labels": {},
                     "limits": {"cpu": "4000m", "memory": "2000Mi"},
                     "requests": {"cpu": "150m", "memory": "750Mi"},
+                    "pull_policy": "Always",
+
                 },
                 "dagster_chart_config": {
                     "deployments_configmap_name": "dagster-user-deployments-values-yaml",


### PR DESCRIPTION
Fixing an edge case.
Situation: Container Registry is wiped. Dagster-UC's gen-tag restarts at 1. Kubernetes Image Cache still has the original -1 image for a deployment, so it doesn't pull the new image, just reuses the old one. By setting PullPolicy to Always, this can handle the edge case if for some reason the image cache can't be cleared (say... due to permissions). The default remains IfNotPresent