### PR TITLE
adding the ability to pass in additional env vars during CLI

### DIFF
--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -426,7 +426,7 @@ def deployment_deploy(
             key_value = eea.split("=")
             if len(key_value) != 2:
                 raise ValueError(f"{eea} is not in the format key=value")
-            config.user_code_deployment_env.append(KubernetesEnvVar(name=eea[0], value=eea[1]))
+            config.KubernetesConfiguration.user_code_deployment_env.append(KubernetesEnvVar(name=eea[0], value=eea[1]))
     count = 0
     while not handler.acquire_semaphore(reset_lock):
         logger.error(

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -424,7 +424,7 @@ def deployment_deploy(
     handler._ensure_dagster_version_match()
     if extra_env_args is not None:
         for eea in extra_env_args:
-            pattern = r"^(\w+)=(\S+)$" #captures in key=value format
+            pattern = r"^(\w+)=(\S+)$"  # captures in key=value format
 
             match = re.match(pattern, eea)
             if match:

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -427,7 +427,7 @@ def deployment_deploy(
             if len(key_value) != 2:
                 raise ValueError(f"{eea} is not in the format key=value")
             config.KubernetesConfiguration.user_code_deployment_env.append(
-                KubernetesEnvVar(name=eea[0], value=eea[1])
+                KubernetesEnvVar(name=eea[0], value=eea[1]),
             )
     count = 0
     while not handler.acquire_semaphore(reset_lock):

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -426,7 +426,9 @@ def deployment_deploy(
             key_value = eea.split("=")
             if len(key_value) != 2:
                 raise ValueError(f"{eea} is not in the format key=value")
-            config.KubernetesConfiguration.user_code_deployment_env.append(KubernetesEnvVar(name=eea[0], value=eea[1]))
+            config.KubernetesConfiguration.user_code_deployment_env.append(
+                KubernetesEnvVar(name=eea[0], value=eea[1])
+            )
     count = 0
     while not handler.acquire_semaphore(reset_lock):
         logger.error(

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -426,7 +426,7 @@ def deployment_deploy(
             key_value = eea.split("=")
             if len(key_value) != 2:
                 raise ValueError(f"{eea} is not in the format key=value")
-            config.KubernetesConfiguration.user_code_deployment_env.append(
+            config.kubernetes_config.user_code_deployment_env.append(
                 KubernetesEnvVar(name=eea[0], value=eea[1]),
             )
     count = 0

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import pprint
+import re
 import time
 from typing import Annotated, cast
 
@@ -423,12 +424,16 @@ def deployment_deploy(
     handler._ensure_dagster_version_match()
     if extra_env_args is not None:
         for eea in extra_env_args:
-            key_value = eea.split("=")
-            if len(key_value) != 2:
-                raise ValueError(f"{eea} is not in the format key=value")
-            config.kubernetes_config.user_code_deployment_env.append(
-                KubernetesEnvVar(name=eea[0], value=eea[1]),
-            )
+            pattern = r"^(\w+)=(\S+)$" #captures in key=value format
+
+            match = re.match(pattern, eea)
+            if match:
+                key, value = match.groups()  # Extract the groups
+                config.kubernetes_config.user_code_deployment_env.append(
+                    KubernetesEnvVar(name=key, value=value),
+                )
+            else:
+                raise ValueError(f"{eea} is not in key=value format")
     count = 0
     while not handler.acquire_semaphore(reset_lock):
         logger.error(

--- a/dagster_uc/manage_user_code_deployments.py
+++ b/dagster_uc/manage_user_code_deployments.py
@@ -19,6 +19,7 @@ from dagster_uc.config import (
     DagsterUserCodeConfiguration,
     DockerConfiguration,
     KubernetesConfiguration,
+    KubernetesEnvVar,
     load_config,
 )
 from dagster_uc.log import logger
@@ -410,10 +411,22 @@ def deployment_deploy(
             help="If this is provided, ignore the check for if podman is installed. This is used for some CI/CD environments that require podman to always be in sudo mode",
         ),
     ] = False,
+    extra_env_args: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--extra-env",
+            help="If this is provided in the format 'key=value', this supplies extra key-value pairs to user_code_deployment_env, if an option is provided that is not in this format, an error is raised",
+        ),
+    ] = None,
 ):
     """Handles deployment to kubernetes cluster."""
     handler._ensure_dagster_version_match()
-
+    if extra_env_args is not None:
+        for eea in extra_env_args:
+            key_value = eea.split("=")
+            if len(key_value) != 2:
+                raise ValueError(f"{eea} is not in the format key=value")
+            config.user_code_deployment_env.append(KubernetesEnvVar(name=eea[0], value=eea[1]))
     count = 0
     while not handler.acquire_semaphore(reset_lock):
         logger.error(


### PR DESCRIPTION
Added the ability to pass in additional environment variables when calling deploy. This allows for at-deployment calls (such as passing a limited_data variable into dagster for testing purposes) that don't really belong in a permanent config file. 

Each env var is passed in via --extra-env key=value like `dagster-uc deployment deploy --env-var limited_data=True`